### PR TITLE
Add random seed option

### DIFF
--- a/DimonSmart.MazeGenerator/MazeBuilder.cs
+++ b/DimonSmart.MazeGenerator/MazeBuilder.cs
@@ -1,7 +1,8 @@
 ﻿namespace DimonSmart.MazeGenerator;
 
-public class MazeBuilder<TCell>(IMaze<TCell> Maze, MazeBuildOptions? Options = null) : IMazeBuilder where TCell : ICell
+public class MazeBuilder<TCell>(IMaze<TCell> Maze, MazeBuildOptions? Options = null, Random? Random = null) : IMazeBuilder where TCell : ICell
 {
+    private readonly Random _random = Random ?? System.Random.Shared;
     private bool _done;
 
     public void Build(IMazePlotter? plotter = null, CancellationToken cancellationToken = default)
@@ -24,7 +25,7 @@ public class MazeBuilder<TCell>(IMaze<TCell> Maze, MazeBuildOptions? Options = n
 
     private async Task DrawLine(int x, int y, Func<int, int, Task> plotAction, CancellationToken cancellationToken)
     {
-        var randomNumber = Random.Shared.Next(0, 4);
+        var randomNumber = _random.Next(0, 4);
         switch (randomNumber)
         {
             case 0:
@@ -45,7 +46,7 @@ public class MazeBuilder<TCell>(IMaze<TCell> Maze, MazeBuildOptions? Options = n
     private async Task DrawLine(int x, int y, int dx, int dy, Func<int, int, Task> plotAction,
         CancellationToken cancellationToken)
     {
-        if (Random.Shared.NextDouble() < (Options?.Emptiness ?? 0.0))
+        if (_random.NextDouble() < (Options?.Emptiness ?? 0.0))
         {
             return;
         }
@@ -64,7 +65,7 @@ public class MazeBuilder<TCell>(IMaze<TCell> Maze, MazeBuildOptions? Options = n
 
             Maze.MakeWall(x, y);
             await plotAction(x, y);
-            if (x % 2 == 0 && y % 2 == 0 && Random.Shared.NextDouble() < (Options?.WallShortness ?? 0.0))
+            if (x % 2 == 0 && y % 2 == 0 && _random.NextDouble() < (Options?.WallShortness ?? 0.0))
             {
                 break;
             }
@@ -82,7 +83,7 @@ public class MazeBuilder<TCell>(IMaze<TCell> Maze, MazeBuildOptions? Options = n
         }
 
         await CreateBorder(plotAction, cancellationToken);
-        foreach (var point in GetAllPossibleStartPoints().OrderBy(_ => Random.Shared.Next()))
+        foreach (var point in GetAllPossibleStartPoints().OrderBy(_ => _random.Next()))
         {
             await DrawLine(point.X, point.Y, plotAction, cancellationToken);
         }

--- a/DimonSmart.MazeGeneratorConsoleDemo/Program.cs
+++ b/DimonSmart.MazeGeneratorConsoleDemo/Program.cs
@@ -14,7 +14,8 @@ internal class Program
         var maze = new Maze<Cell>(31, 21);
         var mazePlotter = new MazeConsolePlotter();
 
-        new MazeBuilder<Cell>(maze, new MazeBuildOptions(0.1, 0.0)).Build(mazePlotter);
+        var random = new Random(0);
+        new MazeBuilder<Cell>(maze, new MazeBuildOptions(0.1, 0.0), random).Build(mazePlotter);
 
         var wave = new MazeWaveGenerator<Cell>(maze, mazePlotter).GenerateWave(1, 1, 29, 19);
         var pathBuilder = new MazePathBuilder(wave, mazePlotter);

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ This example demonstrates how to generate a maze without any visualization.
 The MazeBuilder is invoked without a plotter, so the maze is created silently.
 ```csharp
 var maze = new Maze<Cell>(31, 21);
-new MazeBuilder<Cell>(maze).Build();
+var random = new Random(0); // use a seed for repeatable mazes
+new MazeBuilder<Cell>(maze, null, random).Build();
 ```
 
 ### Example 2: Maze Generation with Progress Visualization
@@ -60,7 +61,8 @@ A MazeConsolePlotter instance is passed to the MazeBuilder to display the buildi
 ```csharp
 var maze = new Maze<Cell>(31, 21);
 var mazePlotter = new MazeConsolePlotter();
-new MazeBuilder<Cell>(maze, new MazeBuildOptions(0.50, 0.0)).Build(mazePlotter);
+var random = new Random(0); // seed for repeatable results
+new MazeBuilder<Cell>(maze, new MazeBuildOptions(0.50, 0.0), random).Build(mazePlotter);
 ```
 
 ### Example 3: Wave Generation for Pathfinding
@@ -71,7 +73,8 @@ This example showcases the full process:
 ```csharp
 var maze = new Maze<Cell>(31, 21);
 var mazePlotter = new MazeConsolePlotter();
-new MazeBuilder<Cell>(maze, new MazeBuildOptions(0.50, 0.0)).Build(mazePlotter);
+var random = new Random(0); // deterministic maze
+new MazeBuilder<Cell>(maze, new MazeBuildOptions(0.50, 0.0), random).Build(mazePlotter);
 
 var wave = new MazeWaveGenerator<Cell>(maze, mazePlotter).GenerateWave(1, 1, 29, 19);
 var pathBuilder = new MazePathBuilder(wave, mazePlotter);


### PR DESCRIPTION
## Summary
- make MazeBuilder accept an optional `Random` instance
- use that `Random` in maze generation logic
- update console demo to show seeding
- document seeding usage in README

## Testing
- `dotnet build MazeGenerator.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ead1b596c832ab1ebc7b4cada5271